### PR TITLE
Install into $(DESTDIR), not '/' by default

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -1,4 +1,4 @@
-INSTALLROOT:= /
+INSTALLROOT:= $(DESTDIR)
 PREFIX := /usr
 
 HOSTARCH   = $(shell uname -m | sed s,i[3456789]86,ia32,)


### PR DESCRIPTION
In order to be built in a "normal" buildsystem, DESTDIR needs to be
honored.

Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
