### PR TITLE
Preserve timestamp during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean :
 install :
 	@for x in $(SUBDIRS) ; do $(MAKE) -C $${x} TOPDIR=$(TOPDIR) SRCDIR=$(TOPDIR)/$@/ ARCH=$(ARCH) $@ ; done
 	$(INSTALL) -d -m 755 $(INSTALLROOT)$(PREFIX)$(DOCDIR)/pesign/
-	$(INSTALL) -m 644 COPYING $(INSTALLROOT)$(PREFIX)$(DOCDIR)/pesign/
+	$(INSTALL) -pm 644 COPYING $(INSTALLROOT)$(PREFIX)$(DOCDIR)/pesign/
 
 install_systemd:
 	@for x in $(SUBDIRS) ; do $(MAKE) -C $${x} TOPDIR=$(TOPDIR) SRCDIR=$(TOPDIR)/$@/ ARCH=$(ARCH) $@ ; done


### PR DESCRIPTION
  -p, --preserve-timestamps   apply access/modification times of SOURCE files to corresponding destination files
