### PR TITLE
Fix race condition in SEC_GetPassword

### DIFF
--- a/src/password.c
+++ b/src/password.c
@@ -71,9 +71,9 @@ static char *SEC_GetPassword(FILE *input, FILE *output, char *prompt,
     for (;;) {
 	/* Prompt for password */
 	if (isTTY) {
+	    echoOff(infd);
 	    fprintf(output, "%s", prompt);
             fflush (output);
-	    echoOff(infd);
 	}
 
 	fgets ( phrase, sizeof(phrase), input);


### PR DESCRIPTION
A side effect of echoOff is to discard unread input, so if we print the
prompt before echoOff, the user (or process) at the other end might
react to it by writing the password in between those steps, which is
then discarded.  This bit me when trying to drive pesign with an expect
script.

Signed-off-by: Julien Cristau <jcristau@debian.org>