### PR TITLE
sort input files

### DIFF
--- a/libdpe/Makefile
+++ b/libdpe/Makefile
@@ -9,7 +9,7 @@ LIBTARGETS=libdpe.so
 STATICLIBTARGETS=libdpe.a
 TARGETS=$(LIBTARGETS) $(STATICLIBTARGETS)
 
-LIBDPE_SOURCES = $(wildcard *.c)
+LIBDPE_SOURCES = $(sort $(wildcard *.c))
 ALL_SOURCES=$(LIBDPE_SOURCES)
 -include $(call deps-of,$(ALL_SOURCES))
 


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.