### PR TITLE
sysvinit: Create the socket directory at runtime

### DIFF
--- a/src/pesign.sysvinit.in
+++ b/src/pesign.sysvinit.in
@@ -20,6 +20,9 @@ RETVAL=0
 
 start(){
     echo -n "Starting pesign: "
+    mkdir /var/run/pesign 2>/dev/null &&
+        chown pesign:pesign /var/run/pesign &&
+        chmod 0770 /var/run/pesign
     daemon /usr/bin/pesign --daemonize
     RETVAL=$?
     echo


### PR DESCRIPTION
This better supports non-systemd configurations with tmpfs on `/var/run`.

Note that the intent here is to not modify the directory if it already exists, so as not to clash with packaging or end-user configuration.  This setup could get ugly if the script is run without the `pesign` user and group defined, but the daemon itself requires them, so something else would be broken in that case.