### PR TITLE
Add missing quotes in RPM macros (fixes RHBZ#1508094)

### DIFF
--- a/src/macros.pesign
+++ b/src/macros.pesign
@@ -9,8 +9,8 @@
 %__pesign_token %{nil}%{?pe_signing_token:-t "%{pe_signing_token}"}
 %__pesign_cert %{!?pe_signing_cert:"Red Hat Test Certificate"}%{?pe_signing_cert:"%{pe_signing_cert}"}
 
-%__pesign_client_token %{!?pe_signing_token:"Fedora Signer (OpenSC Card)"}%{?pe_signing_token:"%{pe_signing_token}}
-%__pesign_client_cert %{!?pe_signing_cert:"/CN=Fedora Secure Boot Signer"}%{?pe_signing_cert:"%{pe_signing_cert}}
+%__pesign_client_token %{!?pe_signing_token:"Fedora Signer (OpenSC Card)"}%{?pe_signing_token:"%{pe_signing_token}"}
+%__pesign_client_cert %{!?pe_signing_cert:"/CN=Fedora Secure Boot Signer"}%{?pe_signing_cert:"%{pe_signing_cert}"}
 
 %_pesign /usr/bin/pesign
 %_pesign_client /usr/bin/pesign-client


### PR DESCRIPTION
Patch taken from Peter Backes at:

https://bugzilla.redhat.com/show_bug.cgi?id=1508094