### PR TITLE
efisiglist: Copy the header correctly

### DIFF
--- a/src/siglist.c
+++ b/src/siglist.c
@@ -217,7 +217,10 @@ signature_list_realize(signature_list *sl, void **out, size_t *outsize)
 		return -1;
 	esl = ret;
 
-	memcpy(esl, sl, sizeof (*esl));
+	memcpy(&esl->SignatureType, sl->SignatureType, sizeof(efi_guid_t));
+	esl->SignatureListSize = sl->SignatureListSize;
+	esl->SignatureHeaderSize = sl->SignatureHeaderSize;
+	esl->SignatureSize = sl->SignatureSize;
 
 	uint8_t *pos = ret + sizeof (*esl);
 	for (int i = 0; i < count; i++) {


### PR DESCRIPTION
signature_list wasn't copied corretly to efi_signature_list because
SignatureType in signature_list is a pointer while that in
efi_signature_list is not.

Signed-off-by: Gary Lin <glin@suse.com>