### PR TITLE
Send pesign stdout/err to systemd journal

### DIFF
--- a/src/pesign.service.in
+++ b/src/pesign.service.in
@@ -3,7 +3,6 @@ Description=Pesign signing daemon
 
 [Service]
 PrivateTmp=true
-Type=forking
 PIDFile=/var/run/pesign.pid
-ExecStart=/usr/bin/pesign --daemonize
+ExecStart=/usr/bin/pesign --daemonize --nofork
 ExecStartPost=@@LIBEXECDIR@@/pesign/pesign-authorize


### PR DESCRIPTION
This will simplify troubleshooting pesign as by default messages will now be sent to the journal rather than nowhere.