### PR TITLE
Short delay to ensure /run/pesign/socket exists

### DIFF
--- a/src/pesign-authorize
+++ b/src/pesign-authorize
@@ -47,7 +47,8 @@ update_subdir() {
 	done
 }
 
-for x in /var/run/pesign/ /etc/pki/pesign*/ ; do
+sleep 3
+for x in /etc/pki/pesign*/ /var/run/pesign/ ; do
 	if [ -d "${x}" ]; then
 		update_subdir "${x}"
 	else


### PR DESCRIPTION
On my system pesign-authorize ends up running before the socket is created.  I've added a slight delay and rearranged the directory scan.  This provides sufficient delay on my system.