### PR TITLE
pesigcheck: remove superfluous type settings

### DIFF
--- a/src/pesigcheck.c
+++ b/src/pesigcheck.c
@@ -318,7 +318,6 @@ check_signature(pesigcheck_context *ctx, int *nreasons,
 			reason->type = SIGNATURE;
 			reason->sig.data = data;
 			reason->sig.len = datalen;
-			reason->type = siBuffer;
 			nreason += 1;
 			is_invalid = true;
 		}
@@ -330,7 +329,6 @@ check_signature(pesigcheck_context *ctx, int *nreasons,
 			reason->type = SIGNATURE;
 			reason->sig.data = data;
 			reason->sig.len = datalen;
-			reason->type = siBuffer;
 			nreason += 1;
 			has_valid_cert = true;
 		}


### PR DESCRIPTION
When setting the type of reason in check_signature(), the type was
accidentally set as "siBuffer". Since the type is already set as
"SIGNATURE", we only need to remove those two lines of code.

Fixes: https://github.com/rhboot/pesign/issues/55

Signed-off-by: Gary Lin <glin@suse.com>