### PR TITLE
Resolve crash when signature that is removed is not the end of the list

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -446,11 +446,12 @@ remove_signature(pesign_context *p_ctx)
 	cms_context *ctx = p_ctx->cms_ctx;
 
 	free(ctx->signatures[p_ctx->signum]->data);
+	free(ctx->signatures[p_ctx->signum]);
 	if (p_ctx->signum != ctx->num_signatures - 1)
-		memmove(ctx->signatures[p_ctx->signum],
-			ctx->signatures[p_ctx->signum+1],
-			sizeof(SECItem) *
-				(ctx->num_signatures - 1));
+		memmove(&ctx->signatures[p_ctx->signum],
+			&ctx->signatures[p_ctx->signum+1],
+			sizeof(SECItem*) *
+				(ctx->num_signatures - p_ctx->signum - 1));
 
 	ctx->num_signatures--;
 }


### PR DESCRIPTION
Noticed this when I was removing signatures on a file that was going to be distributed for one of the products. pesign will crash due to memory corruption if this memmove is executed.

Here are some examples of the pointers before and after fixing the issue:

Without the change:
```
$ pesign -r -u 0 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new
before: sig[0]=0x5582aa9ba790 sig[0]->data=0x5582aa9ba7b0
before: sig[1]=0x5582aa9bad20 sig[1]->data=0x5582aa9bad40
before: sig[2]=0x5582aa9bb430 sig[2]->data=0x5582aa9bb450
after : sig[0]=0x5582aa9ba790 sig[0]->data=0x5582aa9bad40
after : sig[1]=0x5582aa9bad20 sig[1]->data=0x5582aa9bad40
malloc(): invalid next size (unsorted)
[1]    1014756 abort (core dumped)  ~/Downloads/pesign/src/pesign -r -u 0 -i EFI/BOOT/bootx64.efi1 -o 
```

```
$ pesign -r -u 1 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new
before: sig[0]=0x55823de4e790 sig[0]->data=0x55823de4e7b0
before: sig[1]=0x55823de4ed20 sig[1]->data=0x55823de4ed40
before: sig[2]=0x55823de4f430 sig[2]->data=0x55823de4f450
after : sig[0]=0x55823de4e790 sig[0]->data=0x55823de4e7b0
after : sig[1]=0x55823de4ed20 sig[1]->data=0x55823de4f450
malloc(): invalid next size (unsorted)
[1]    1014767 abort (core dumped)  ~/Downloads/pesign/src/pesign -r -u 1 -i EFI/BOOT/bootx64.efi1 -o 
```

```
pesign -r -u 2 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new 
before: sig[0]=0x55aea779e790 sig[0]->data=0x55aea779e7b0
before: sig[1]=0x55aea779ed20 sig[1]->data=0x55aea779ed40
before: sig[2]=0x55aea779f430 sig[2]->data=0x55aea779f450
after : sig[0]=0x55aea779e790 sig[0]->data=0x55aea779e7b0
after : sig[1]=0x55aea779ed20 sig[1]->data=0x55aea779ed40
```

With the change:
```
$ pesign -r -u 0 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new
before: sig[0]=0x55e1bfdf8790 sig[0]->data=0x55e1bfdf87b0
before: sig[1]=0x55e1bfdf8d20 sig[1]->data=0x55e1bfdf8d40
before: sig[2]=0x55e1bfdf9430 sig[2]->data=0x55e1bfdf9450
after : sig[0]=0x55e1bfdf8d20 sig[0]->data=0x55e1bfdf8d40
after : sig[1]=0x55e1bfdf9430 sig[1]->data=0x55e1bfdf9450
```

```
$ pesign -r -u 1 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new
before: sig[0]=0x55c8af626790 sig[0]->data=0x55c8af6267b0
before: sig[1]=0x55c8af626d20 sig[1]->data=0x55c8af626d40
before: sig[2]=0x55c8af627430 sig[2]->data=0x55c8af627450
after : sig[0]=0x55c8af626790 sig[0]->data=0x55c8af6267b0
after : sig[1]=0x55c8af627430 sig[1]->data=0x55c8af627450
```

```
pesign -r -u 2 -i EFI/BOOT/bootx64.efi -o EFI/BOOT/bootx64.efi.new 
before: sig[0]=0x55aea779e790 sig[0]->data=0x55aea779e7b0
before: sig[1]=0x55aea779ed20 sig[1]->data=0x55aea779ed40
before: sig[2]=0x55aea779f430 sig[2]->data=0x55aea779f450
after : sig[0]=0x55aea779e790 sig[0]->data=0x55aea779e7b0
after : sig[1]=0x55aea779ed20 sig[1]->data=0x55aea779ed40
```

Let me know if there's anything I should do in order to help get this in :)