### PR TITLE
Enhance error diagnostics about version mismatch

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -135,7 +135,7 @@ check_cmd_version(int sd, uint32_t command, char *name, int32_t version)
 	if (rc < 0)
 		errx(1, "command \"%s\" not known by server", name);
 	if (rc != version)
-		errx(1, "command \"%s\": client version %d, server version %d",
+		errx(1, "command \"%s\": client version %#x, server version %#x",
 			name, version, rc);
 }
 
@@ -199,8 +199,8 @@ check_response(int sd, char **srvmsg)
 	pm = (pesignd_msghdr *)buffer;
 
 	if (pm->version != PESIGND_VERSION) {
-		fprintf(stderr, "pesign-client: got version %d, "
-			"expected version %d\n", pm->version, PESIGND_VERSION);
+		fprintf(stderr, "pesign-client: got version %#x, "
+			"expected version %#x\n", pm->version, PESIGND_VERSION);
 		exit(1);
 	}
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -856,7 +856,7 @@ handle_event(context *ctx, struct pollfd *pollfd)
 
 	if (pm.version != PESIGND_VERSION) {
 		ctx->backup_cms->log(ctx->backup_cms, ctx->priority|LOG_ERR,
-			"got version %d, expected version %d",
+			"got version %#x, expected version %#x",
 			pm.version, PESIGND_VERSION);
 		ctx->backup_cms->log(ctx->backup_cms, ctx->priority|LOG_ERR,
 			"possible exploit attempt.  closing.");


### PR DESCRIPTION
When version mismatch is detected, print both versions in hexadecimal
format which is also the format used in PESIGND_VERSION macro definition.

This change helps to identify versions used on both sides in case of
mismatch.

Signed-off-by: Dmitry V. Levin <ldv@altlinux.org>