### PR TITLE
macros: drop %{_pesign_args}

### DIFF
--- a/src/macros.pesign
+++ b/src/macros.pesign
@@ -27,7 +27,6 @@
   %{_libexecdir}/pesign/pesign-rpmbuild-helper				\\\
     "%{_target_cpu}"							\\\
     "%{_pesign}"							\\\
-    "%{_pesign_args}"							\\\
     "%{_pesign_client}"							\\\
     %{?__pesign_client_token:--client-token %{__pesign_client_token}}	\\\
     %{?__pesign_client_cert:--client-cert %{__pesign_client_cert}}	\\\

--- a/src/pesign-rpmbuild-helper.in
+++ b/src/pesign-rpmbuild-helper.in
@@ -133,6 +133,11 @@ main() {
 	sign=-s
 	shift
     fi
+    if [[ $# -ge 1 ]] ; then
+	echo "$# extra unparsed arguments!">>/dev/stderr
+	echo "Cowardly refusing to run">>/dev/stderr
+	exit 1
+    fi
 
     if [[ -z "${target_cpu}" ]] ; then
 	target_cpu="$(uname -m)"


### PR DESCRIPTION
Effectively reverts 30b488682a92c524bb9c0d450c34e9abc0b56de9

Also, make our argument parser fail on extra arguments to make it easier
to debug when this kind of thing happens again.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>