### PR TITLE
daemon: remove always-true comparison

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -221,8 +221,7 @@ malformed:
 	if (!ctx->cms->tokenname)
 		goto oom;
 
-	if (!tp->value)
-		pin = strndup((char *)tp->value, tp->size);
+	pin = strndup((char *)tp->value, tp->size);
 	if (!pin)
 		goto oom;
 


### PR DESCRIPTION
Signed-off-by: Robbie Harwood <rharwood@redhat.com>