### PR TITLE
pesigcheck: Fix crash on digest match

### DIFF
--- a/src/certdb.c
+++ b/src/certdb.c
@@ -267,12 +267,16 @@ check_hash(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 
 	if (memcmp(sigtype, &efi_sha256, sizeof(efi_guid_t)) == 0) {
 		digest = ctx->cms_ctx->digests[0].pe_digest->data;
-		if (memcmp (digest, sig->data, 32) == 0)
+		if (memcmp (digest, sig->data, 32) == 0) {
+			ctx->cms_ctx->selected_digest = 0;
 			return FOUND;
+		}
 	} else if (memcmp(sigtype, &efi_sha1, sizeof(efi_guid_t)) == 0) {
 		digest = ctx->cms_ctx->digests[1].pe_digest->data;
-		if (memcmp (digest, sig->data, 20) == 0)
+		if (memcmp (digest, sig->data, 20) == 0) {
+			ctx->cms_ctx->selected_digest = 1;
 			return FOUND;
+		}
 	}
 
 	return NOT_FOUND;


### PR DESCRIPTION
Set selected_digest when the digest is found in db or dbx.
This fixes a crash in get_digest().

Signed-off-by: Visa Hankala <visa@hankala.org>