### PR TITLE
cms: store digest as pointer instead of index

### DIFF
--- a/src/certdb.c
+++ b/src/certdb.c
@@ -263,18 +263,19 @@ check_hash(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 {
 	efi_guid_t efi_sha256 = efi_guid_sha256;
 	efi_guid_t efi_sha1 = efi_guid_sha1;
-	void *digest;
+	void *digest_data;
+	struct digest *digests = ctx->cms_ctx->digests;
 
 	if (memcmp(sigtype, &efi_sha256, sizeof(efi_guid_t)) == 0) {
-		digest = ctx->cms_ctx->digests[0].pe_digest->data;
-		if (memcmp (digest, sig->data, 32) == 0) {
-			ctx->cms_ctx->selected_digest = 0;
+		digest_data = digests[0].pe_digest->data;
+		if (memcmp (digest_data, sig->data, 32) == 0) {
+			ctx->cms_ctx->selected_digest = &digests[0];
 			return FOUND;
 		}
 	} else if (memcmp(sigtype, &efi_sha1, sizeof(efi_guid_t)) == 0) {
-		digest = ctx->cms_ctx->digests[1].pe_digest->data;
-		if (memcmp (digest, sig->data, 20) == 0) {
-			ctx->cms_ctx->selected_digest = 1;
+		digest_data = digests[1].pe_digest->data;
+		if (memcmp (digest_data, sig->data, 20) == 0) {
+			ctx->cms_ctx->selected_digest = &digests[1];
 			return FOUND;
 		}
 	}

--- a/src/cms_common.h
+++ b/src/cms_common.h
@@ -12,6 +12,7 @@
 #include <secpkcs7.h>
 
 #include <errno.h>
+#include <efivar.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <sys/types.h>
@@ -57,9 +58,19 @@
 		goto errlabel;						\
 	})
 
+struct digest_param {
+	char *name;
+	SECOidTag digest_tag;
+	SECOidTag signature_tag;
+	SECOidTag digest_encryption_tag;
+	const efi_guid_t *efi_guid;
+	int size;
+};
+
 struct digest {
 	PK11Context *pk11ctx;
 	SECItem *pe_digest;
+	struct digest_param *digest_params;
 };
 
 typedef struct pk12_file {
@@ -133,7 +144,7 @@ typedef struct cms_context {
 	int db_out, dbx_out, dbt_out;
 
 	struct digest *digests;
-	int selected_digest;
+	struct digest *selected_digest;
 	int omit_vendor_cert;
 
 	SECItem newsig;

--- a/src/content_info.c
+++ b/src/content_info.c
@@ -181,8 +181,8 @@ generate_spc_digest_info(cms_context *cms, SECItem *dip)
 	if (generate_algorithm_id(cms, &di.digestAlgorithm,
 			digest_get_digest_oid(cms)) < 0)
 		return -1;
-	int i = cms->selected_digest;
-	memcpy(&di.digest, cms->digests[i].pe_digest, sizeof (di.digest));
+	memcpy(&di.digest, cms->selected_digest->pe_digest,
+	       sizeof(di.digest));
 
 	if (content_is_empty(di.digest.data, di.digest.len)) {
 		cms->log(cms, LOG_ERR, "got empty digest");

--- a/src/file_kmod.c
+++ b/src/file_kmod.c
@@ -60,7 +60,7 @@ ssize_t
 kmod_write_signature(cms_context *cms, int outfd)
 {
 	SEC_PKCS7ContentInfo *cinfo;
-	SECItem *digest = cms->digests[cms->selected_digest].pe_digest;
+	SECItem *digest = cms->selected_digest->pe_digest;
 	SECStatus rv;
 	struct write_sig_info info = {
 		.outfd = outfd,

--- a/src/file_pe.c
+++ b/src/file_pe.c
@@ -114,6 +114,8 @@ check_inputs(pesign_context *ctx)
 static void
 print_digest(pesign_context *pctx)
 {
+	unsigned int i;
+
 	if (!pctx)
 		return;
 
@@ -121,10 +123,9 @@ print_digest(pesign_context *pctx)
 	if (!ctx)
 		return;
 
-	int j = ctx->selected_digest;
-	for (unsigned int i = 0; i < ctx->digests[j].pe_digest->len; i++)
-		printf("%02x",
-			(unsigned char)ctx->digests[j].pe_digest->data[i]);
+	unsigned char *ddata = ctx->selected_digest->pe_digest->data;
+	for (i = 0; i < ctx->selected_digest->pe_digest->len; i++)
+		printf("%02x", ddata[i]);
 	printf(" %s\n", pctx->infile);
 }
 

--- a/src/pesigcheck.c
+++ b/src/pesigcheck.c
@@ -221,9 +221,7 @@ static void
 get_digest(pesigcheck_context *ctx, SECItem *digest)
 {
 	struct cms_context *cms = ctx->cms_ctx;
-	struct digest *cms_digest = &cms->digests[cms->selected_digest];
-
-	memcpy(digest, cms_digest->pe_digest, sizeof (*digest));
+	memcpy(digest, cms->selected_digest->pe_digest, sizeof(*digest));
 }
 
 static int


### PR DESCRIPTION
Storage as an index is problematic because the sentinel value -1 was
used, but accesses were unchecked, leading to crashes like that in
3b1031a6b779cb80c11b34eec84c5a0cc215efed ("pesigcheck: Fix crash on
digest match").  By storing a pointer, we get an explicit NULL
dereference: still a crash, but preferred since it's clearer.

Since the index was previously also used for retrieving digest
parameters, include a pointer to the relevant struct digest_param in the
struct digest.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

[This is the refactor suggested in #90.]