### PR TITLE
Fix mandoc invocation to not produce garbage

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -54,7 +54,7 @@ define substitute-version =
 endef
 
 %.1 : %.1.mdoc
-	@mandoc -man -Ios=Linux $^ > $@
+	@mandoc -man -T man -Ios=Linux $^ > $@
 
 % : %.in
 	@$(call substitute-version,$<,$@)


### PR DESCRIPTION
Bizarrely, mandoc doesn't default to outputting man - the default is
"locale", which is either ASCII or UTF-8 (by locale).  This output is
supposed to be some kind of plain-text, but it's formatted so strangely
I'm not sure what the purpose is.  Regardless, it doesn't go well to
feed this into man(1).

Tell mandoc explicitly to produce man pages.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

[It's not clear to me why we're using mandoc at all.  The mdoc files appear to be valid man pages already.]