### PR TITLE
src/certs/make-certs: delete the duplicate codes

### DIFF
--- a/src/certs/make-certs
+++ b/src/certs/make-certs
@@ -30,10 +30,6 @@ commonname="$1"
 refresh_crl=false
 revoke_cert=false
 ocsp_serve=false
-if test "x$commonname" = "x-refresh-crl" ; then
-	refresh_crl=true
-	commonname="$1"
-fi
 if test "x$commonname" = "x-refresh_crl" ; then
 	refresh_crl=true
 	commonname="$1"


### PR DESCRIPTION
In make-certs, the codes of lines 33-36 is duplicate with the codes of lines 37-40, so delete the duplicate codes.

Fixes: #96

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>