### PR TITLE
cms_common: fix cert match check

### DIFF
--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -872,7 +872,7 @@ find_certificate_by_callback(cms_context *cms,
 			continue;
 
 		int rc = match(tmpnode->cert, cbdata);
-		if (rc == 0) {
+		if (rc == 1) {
 			node = tmpnode;
 			break;
 		}


### PR DESCRIPTION
In find_certificate_by_callback(), the match() returns 1 when cert subject is matched.

Signed-off-by: Huaxin Lu <luhuaxin1@huawei.com>