### PR TITLE
Free resources if certification cannot be found

### DIFF
--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -878,8 +878,12 @@ find_certificate_by_callback(cms_context *cms,
 		}
 	}
 
-	if (!node)
+	if (!node) {
+		PK11_DestroySlotListElement(slots, &psle);
+		PK11_FreeSlotList(slots);
+		CERT_DestroyCertList(certlist);
 		cnreterr(-1, cms, "Could not find certificate");
+	}
 
 	*cert = CERT_DupCertificate(node->cert);
 


### PR DESCRIPTION
In find_certificate_by_callback, function return -1 directly without free resource if node is null, that will lead to nss shut down failed.

The error message as below:
could not shut down NSS: NSS could not shutdown. Objects are still in use.

To fix this issue, free all resources before function return -1.

Signed-off-by: Chenxi Mao <chenxi.mao@suse.com>