### PR TITLE
cms_common: skip authentication on the 'Friendly' slot

### DIFF
--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -629,7 +629,8 @@ find_certificate(cms_context *cms, int needs_private_key)
 
 	int errnum;
 	SECStatus status;
-	if (PK11_NeedLogin(psle->slot) && !PK11_IsLoggedIn(psle->slot, cms)) {
+	if ((needs_private_key || !PK11_IsFriendly(psle->slot)) &&
+	    (PK11_NeedLogin(psle->slot) && !PK11_IsLoggedIn(psle->slot, cms))) {
 		status = PK11_Authenticate(psle->slot, PR_TRUE, cms);
 		if (status != SECSuccess) {
 			save_port_err() {


### PR DESCRIPTION
When finding a certificate in a 'Friendly' slot without the need of the private key, it is not necessary to authenticate the slot.

Signed-off-by: Gary Lin <glin@suse.com>