### PR TITLE
pesign-rpmbuild-helper.in: Remove verbose execution flag

### DIFF
--- a/src/pesign-rpmbuild-helper.in
+++ b/src/pesign-rpmbuild-helper.in
@@ -2,7 +2,6 @@
 # shellcheck shell=bash
 
 set -eu
-set -x
 
 usage() {
     local status="${1}" && shift


### PR DESCRIPTION
The kernel build logs contain a line-by-line execution of this script.  It does not need to be verbose.  Users wishing to debug the script can add the flag on their own.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>