### PR TITLE
cms_common: Fixed Segmentation fault

### DIFF
--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -957,7 +957,7 @@ find_certificate_by_issuer_and_sn(cms_context *cms,
 	if (!ias)
 		cnreterr(-1, cms, "invalid issuer and serial number");
 
-	return find_certificate_by_callback(cms, match_issuer_and_serial, &ias, cert);
+	return find_certificate_by_callback(cms, match_issuer_and_serial, ias, cert);
 }
 
 int


### PR DESCRIPTION
When running efikeygen, the binary crashes with a segfault due to dereferencing a **ptr instead of a *ptr.