### PR TITLE
daemon: fix pid value by using getpid() in the child process

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -1191,10 +1191,8 @@ daemonize(cms_context *cms_ctx, char *certdir, int do_fork)
 			sleep(2);
 			return 0;
 		}
-		ctx.pid = pid;
-	} else {
-		ctx.pid = getpid();
 	}
+	ctx.pid = getpid();
 	write_pid_file(ctx.pid);
 	ctx.backup_cms->log(ctx.backup_cms, ctx.priority|LOG_NOTICE,
 		"pesignd starting (pid %d)", ctx.pid);


### PR DESCRIPTION
Previously ctx.pid was getting it's value indirectly from fork(), which is always zero in the child process.

Fixed a bug introduced in 2b3ca2b.