### PR TITLE
Make.defaults: Use relative path to include dir.

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -62,7 +62,7 @@ cflags	= $(CFLAGS) $(ARCH3264) \
 	$(call enabled,ENABLE_LEAK_CHECKER,-Wno-analyzer-malloc-leak,) \
 	-Werror -Wno-error=cpp -Wno-free-nonheap-object \
 	-std=gnu11 -fshort-wchar -fPIC -fno-strict-aliasing \
-	-D_GNU_SOURCE -DCONFIG_$(ARCH) -I${TOPDIR}/include \
+	-D_GNU_SOURCE -DCONFIG_$(ARCH) -I../include \
 	'-DRUNDIR="$(rundir)"' \
 	$(if $(filter $(CC),clang),$(clang_cflags), ) \
 	$(if $(filter $(CC),gcc),$(gcc_cflags), ) \


### PR DESCRIPTION
This allows for reproducible builds even when the build path differs between two builds.

https://reproducible-builds.org/docs/build-path/