### PR TITLE
Make.defaults: disable arm32 warnings about wchar_t

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -23,7 +23,7 @@ EFI_ARCHES ?= aa64 ia32 x64
 enabled = $(if $(filter undefined,$(origin $(1))),$(3),$(2))
 
 HOSTARCH   = $(shell uname -m | sed s,i[3456789]86,ia32,)
-ARCH	   := $(shell uname -m | sed s,i[3456789]86,ia32,)
+ARCH	   := $(shell uname -m | sed 's,i[3456789]86,ia32,;s,arm.*,arm,')
 
 
 PKG_CONFIG ?= $(CROSS_COMPILE)pkg-config
@@ -73,6 +73,9 @@ gcc_ccldflags = -fno-merge-constants \
 	-Wl,--fatal-warnings,--no-allow-shlib-undefined,--default-symver \
 	-Wl,-O2 -Wl,--no-undefined-version -Wl,-z,relro,-z,now \
 	-Wl,--no-add-needed,--no-copy-dt-needed-entries,--as-needed -pie
+ifeq ($(ARCH),arm)
+  gcc_ccldflags += -Wl,--no-wchar-size-warning
+endif
 ccldflags = $(cflags) $(CCLDFLAGS) $(LDFLAGS) \
 	$(if $(filter $(CCLD),clang),$(clang_ccldflags),) \
 	$(if $(filter $(CCLD),gcc),$(gcc_ccldflags),) \


### PR DESCRIPTION
Signed-off-by; Steve McIntyre <93sam@debian.org>