### PR TITLE
Fix reversed calloc() arguments

### DIFF
--- a/src/pesigcheck.c
+++ b/src/pesigcheck.c
@@ -240,7 +240,7 @@ check_signature(pesigcheck_context *ctx, int *nreasons,
 
 	cert_iter iter;
 
-	reasonps = calloc(sizeof(struct reason), 512);
+	reasonps = calloc(512, sizeof(struct reason));
 	if (!reasonps)
 		err(1, "check_signature");
 
@@ -281,7 +281,7 @@ check_signature(pesigcheck_context *ctx, int *nreasons,
 
 			num_reasons += 16;
 
-			new_reasons = calloc(sizeof(struct reason), num_reasons);
+			new_reasons = calloc(num_reasons, sizeof(struct reason));
 			if (!new_reasons)
 				err(1, "check_signature");
 			reasonps = new_reasons;


### PR DESCRIPTION
The prototype is "void *calloc(size_t nelem, size_t elsize);"

These two instances had them reversed, almost certainly leading to buffer overflow issues. This was detected by
-Werror=calloc-transposed-args on gcc.

Fixes #117 