### PR TITLE
pesign-rpmbuild-helper: add support for versioned x86_64 arches

### DIFF
--- a/src/pesign-rpmbuild-helper.in
+++ b/src/pesign-rpmbuild-helper.in
@@ -144,7 +144,7 @@ main() {
     fi
 
     target_cpu="${target_cpu/i?86/ia32}"
-    target_cpu="${target_cpu/x86_64/x64}"
+    target_cpu="${target_cpu/x86_64*/x64}"
     target_cpu="${target_cpu/aarch64/aa64}"
     target_cpu="${target_cpu/arm*/arm/}"
 


### PR DESCRIPTION
Recently Red Hat introduced versioned x86_64 arches support in RPM: x86_64_v2 x86_64_v3 x86_64_v4.
This trivial change allows to correctly recognize them as x64.