### PR TITLE
cms: Reduce stack usage in generate_digest()

### DIFF
--- a/src/cms_pe_common.c
+++ b/src/cms_pe_common.c
@@ -278,19 +278,14 @@ generate_digest(cms_context *cms, Pe *pe, int padded)
 			cmsgotoerr(error_shdrs, cms,
 				   "PE has invalid trailing data");
 
+		generate_digest_step(cms, hash_base, hash_size);
+		dbgprintf("digesting %tx + %zx", hash_base - map,
+			hash_size);
 		if (hash_size % 8 != 0 && padded) {
-			size_t tmp_size = hash_size +
-					  ALIGNMENT_PADDING(hash_size, 8);
-			uint8_t tmp_array[tmp_size];
-			memset(tmp_array, '\0', tmp_size);
-			memcpy(tmp_array, hash_base, hash_size);
-			generate_digest_step(cms, tmp_array, tmp_size);
-			dbgprintf("digesting %tx + %zx", (ptrdiff_t)tmp_array,
-				tmp_size);
-		} else {
-			generate_digest_step(cms, hash_base, hash_size);
-			dbgprintf("digesting %tx + %zx", hash_base - map,
-				hash_size);
+			size_t pad_size = ALIGNMENT_PADDING(hash_size, 8);
+			uint8_t pad_array[8] = {0};
+			generate_digest_step(cms, pad_array, pad_size);
+			dbgprintf("padding to %zx", hash_size + pad_size);
 		}
 	}
 	dbgprintf("end of hash");


### PR DESCRIPTION
The existing code copies an unchecked number of bytes onto the stack, adds padding, and then digests that. Instead, digest it directly and then digest the padding separately to avoid the memset and copy onto the stack. At the same time, make the debug message more useful since previously it wrote out an arbitrary userspace pointer.

Before:

...
pesum: 1747920082.420641 cms_pe_common.c:generate_digest():265: digesting ba000 + 1c000 pesum: 1747920082.420692 cms_pe_common.c:generate_digest():265: digesting d6000 + 1000 pesum: 1747920082.421691 cms_pe_common.c:generate_digest():285: digesting 7fffdec34af0 + 1f340 pesum: 1747920082.421744 cms_pe_common.c:generate_digest():293: end of hash ee8240fefb898334933d7a34a6c0d2a9774c13f8c3e58ac0111393b3fdbffd7c shimx64-unsigned.efi

After:

...
pesum: 1747920070.894430 cms_pe_common.c:generate_digest():265: digesting ba000 + 1c000 pesum: 1747920070.894489 cms_pe_common.c:generate_digest():265: digesting d6000 + 1000 pesum: 1747920070.895417 cms_pe_common.c:generate_digest():279: digesting d7000 + 1f33d pesum: 1747920070.895439 cms_pe_common.c:generate_digest():286: padding to 1f340 pesum: 1747920070.895452 cms_pe_common.c:generate_digest():289: end of hash ee8240fefb898334933d7a34a6c0d2a9774c13f8c3e58ac0111393b3fdbffd7c shimx64-unsigned.efi