### PR TITLE
Add loongarch64 (la64) EFI support

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -18,7 +18,7 @@ INSTALLROOT = $(DESTDIR)
 
 INSTALL	?= install
 CROSS_COMPILE	?=
-EFI_ARCHES ?= aa64 ia32 x64
+EFI_ARCHES ?= aa64 ia32 x64 la64
 
 enabled = $(if $(filter undefined,$(origin $(1))),$(3),$(2))
 

--- a/src/pesign-rpmbuild-helper.in
+++ b/src/pesign-rpmbuild-helper.in
@@ -147,6 +147,7 @@ main() {
     target_cpu="${target_cpu/x86_64/x64}"
     target_cpu="${target_cpu/aarch64/aa64}"
     target_cpu="${target_cpu/arm*/arm/}"
+    target_cpu="${target_cpu/loongarch64/la64/}"
 
     local nssdir=/etc/pki/pesign
     if [[ "${#cert[@]}" -eq 2 ]] &&


### PR DESCRIPTION
Add la64 to EFI_ARCHES in Make.defaults, and map loongarch64 to la64 in the pesign-rpmbuild-helper script. This allows building and signing EFI binaries for the loongarch64 architecture.