### PR TITLE
Add branch protection for aarch64 builds

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -56,7 +56,7 @@ ifneq (,$(wildcard /usr/lib/gcc/x86_64-redhat-linux/*/plugin/annobin.so))
   gcc_cflags += -fplugin=annobin
 endif
 
-cflags	= $(CFLAGS) $(ARCH3264) \
+cflags	= $(CFLAGS) $(ARCH3264) $(ARCH_CFLAGS) \
 	-Wall -Wextra -Wsign-compare -Wmissing-prototypes -Wstrict-prototypes -Wno-unused-result \
 	-Wno-unused-function -Wno-missing-field-initializers \
 	$(call enabled,ENABLE_LEAK_CHECKER,-Wno-analyzer-malloc-leak,) \
@@ -103,6 +103,10 @@ ifeq ($(ARCH), x86_64)
   ifeq ($(HOSTARCH), ia32)
     ARCH3264 := -m64
   endif
+endif
+
+ifeq ($(ARCH), aarch64)
+  ARCH_CFLAGS := -mbranch-protection=standard
 endif
 
 # Docs are enabled by default. Set ENABLE_DOCS=0 to disable


### PR DESCRIPTION
Add stack protection so that aarch64 binaries are better protected: https://sourceware.org/annobin/annobin.html/Test-branch-protection.html and so that annocheck tests stop failing
https://artifacts.osci.redhat.com/testing-farm/d3efc626-605d-4ffc-9c42-2f859c5b6111/ :
Hardened: ./usr/bin/pesign: FAIL: dynamic-tags test because the BTI_PLT flag is missing from the dynamic tags