### PR TITLE
PQC/MLDSA: Add support for MLDSA variants

### DIFF
--- a/src/certdb.c
+++ b/src/certdb.c
@@ -18,6 +18,7 @@
 #include <prerror.h>
 #include <cert.h>
 #include <pkcs7t.h>
+#include <sechash.h>
 #include <pk11pub.h>
 
 #include "pesigcheck.h"
@@ -277,7 +278,7 @@ check_hash(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	}
 
 	digest_data = digests[selected_digest].pe_digest->data;
-	size = digest_params[selected_digest].size;
+	size = digest_params[selected_digest].authenticode_digest_size;
 	if (memcmp (digest_data, sig->data, size) == 0) {
 		ctx->cms_ctx->selected_digest = selected_digest;
 		return FOUND;
@@ -346,11 +347,15 @@ check_cert(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	   SECItem *pkcs7sig)
 {
 	SEC_PKCS7ContentInfo *cinfo = NULL;
+	SEC_PKCS7SignerInfo *signer_info = NULL;
 	CERTCertificate *cert = NULL;
 	CERTCertTrust trust;
 	SECItem *content, *digest = NULL;
 	PK11Context *pk11ctx = NULL;
 	SECOidData *oid;
+	SECOidTag digest_tag;
+	HASH_HashType hash_type;
+	unsigned int digest_size;
 	PRBool result;
 	SECStatus rv;
 	db_status status = NOT_FOUND;
@@ -398,16 +403,35 @@ check_cert(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	if (!cinfo)
 		goto out;
 
-	/* Generate the digest of contentInfo */
-	/* XXX support only sha256 for now */
-	digest = SECITEM_AllocItem(NULL, NULL, 32);
+	/*
+	* Generate the digest of contentInfo using the algorithm encoded in
+	* SignerInfo.digestAlgorithm.
+	*/
+	if (cinfo->content.signedData == NULL ||
+	    cinfo->content.signedData->signerInfos == NULL ||
+	    cinfo->content.signedData->signerInfos[0] == NULL)
+		goto out;
+
+	signer_info = cinfo->content.signedData->signerInfos[0];
+
+	digest_tag = SECOID_GetAlgorithmTag(&signer_info->digestAlg);
+	hash_type = HASH_GetHashTypeByOidTag(digest_tag);
+	digest_size = HASH_ResultLenByOidTag(digest_tag);
+
+	if (digest_tag == SEC_OID_UNKNOWN ||
+	    hash_type == HASH_AlgNULL ||
+	    digest_size == 0)
+		goto out;
+
+	digest = SECITEM_AllocItem(NULL, NULL, digest_size);
 	if (digest == NULL)
 		goto out;
 
 	content = cinfo->content.signedData->contentInfo.content.data;
-	oid = SECOID_FindOIDByTag(SEC_OID_SHA256);
+	oid = SECOID_FindOIDByTag(digest_tag);
 	if (oid == NULL)
 		goto out;
+
 	pk11ctx = PK11_CreateDigestContext(oid->offset);
 	if (ctx == NULL)
 		goto out;
@@ -416,7 +440,8 @@ check_cert(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	/*   Skip the SEQUENCE tag */
 	if (PK11_DigestOp(pk11ctx, content->data + 2, content->len - 2) != SECSuccess)
 		goto out;
-	if (PK11_DigestFinal(pk11ctx, digest->data, &digest->len, 32) != SECSuccess)
+	if (PK11_DigestFinal(pk11ctx, digest->data, &digest->len,
+			     digest_size) != SECSuccess)
 		goto out;
 
 	/* Import the trusted certificate */
@@ -445,8 +470,8 @@ check_cert(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	/* Verify the signature */
 	result = SEC_PKCS7VerifyDetachedSignatureAtTime(cinfo,
 						certUsageObjectSigner,
-						digest, HASH_AlgSHA256,
-						PR_FALSE, atTime);
+						digest, hash_type, PR_FALSE,
+						atTime);
 	if (!result) {
 		fprintf(stderr, "%s\n",	PORT_ErrorToString(PORT_GetError()));
 		goto out;

--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -40,54 +40,71 @@
 const struct digest_param digest_params[] = {
 	[DIGEST_PARAM_SHA256] = {
 		.name = "sha256",
-		.digest_tag = SEC_OID_SHA256,
+		.authenticode_digest_tag = SEC_OID_SHA256,
+		.cms_digest_tag = SEC_OID_SHA256,
 		.signature_tag = SEC_OID_PKCS1_SHA256_WITH_RSA_ENCRYPTION,
 		.digest_encryption_tag = SEC_OID_PKCS1_RSA_ENCRYPTION,
 		.efi_guid = &efi_guid_sha256,
-		.size = 32
+		.authenticode_digest_size = 32,
+		.cms_digest_size = 32,
 	},
 #if 1
 	[DIGEST_PARAM_SHA1] = {
 		.name = "sha1",
-		.digest_tag = SEC_OID_SHA1,
+		.authenticode_digest_tag = SEC_OID_SHA1,
+		.cms_digest_tag = SEC_OID_SHA1,
 		.signature_tag = SEC_OID_PKCS1_SHA1_WITH_RSA_ENCRYPTION,
 		.digest_encryption_tag = SEC_OID_PKCS1_RSA_ENCRYPTION,
 		.efi_guid = &efi_guid_sha1,
-		.size = 20
+		.authenticode_digest_size = 20,
+		.cms_digest_size = 20,
 	},
 #endif
 	[DIGEST_PARAM_ML_DSA_44] = {
 		.name = "ml-dsa-44",
-		.digest_tag = SEC_OID_SHA256,
 		.signature_tag = SEC_OID_ML_DSA_44,
+		.authenticode_digest_tag = SEC_OID_SHA256,
+		.cms_digest_tag = SEC_OID_SHA512,
 		.digest_encryption_tag = SEC_OID_ML_DSA_44,
 		.efi_guid = &efi_guid_sha256,
-		.size = 32
+		.authenticode_digest_size = 32,
+		.cms_digest_size = 64,
 	},
 	[DIGEST_PARAM_ML_DSA_65] = {
 		.name = "ml-dsa-65",
-		.digest_tag = SEC_OID_SHA256,
+		.authenticode_digest_tag = SEC_OID_SHA256,
+		.cms_digest_tag = SEC_OID_SHA512,
 		.signature_tag = SEC_OID_ML_DSA_65,
 		.digest_encryption_tag = SEC_OID_ML_DSA_65,
 		.efi_guid = &efi_guid_sha256,
-		.size = 32
+		.authenticode_digest_size = 32,
+		.cms_digest_size = 64,
 	},
 	[DIGEST_PARAM_ML_DSA_87] = {
 		.name = "ml-dsa-87",
-		.digest_tag = SEC_OID_SHA256,
+		.authenticode_digest_tag = SEC_OID_SHA256,
+		.cms_digest_tag = SEC_OID_SHA512,
 		.signature_tag = SEC_OID_ML_DSA_87,
 		.digest_encryption_tag = SEC_OID_ML_DSA_87,
 		.efi_guid = &efi_guid_sha256,
-		.size = 32
+		.authenticode_digest_size = 32,
+		.cms_digest_size = 64,
 	},
 };
 const unsigned int n_digest_params = sizeof (digest_params) / sizeof (digest_params[0]);
 
 SECOidTag
-digest_get_digest_oid(cms_context *cms)
+digest_get_authenticode_oid(cms_context *cms)
 {
 	unsigned int i = cms->selected_digest;
-	return digest_params[i].digest_tag;
+	return digest_params[i].authenticode_digest_tag;
+}
+
+SECOidTag
+digest_get_cms_oid(cms_context *cms)
+{
+	unsigned int i = cms->selected_digest;
+	return digest_params[i].cms_digest_tag;
 }
 
 SECOidTag
@@ -105,10 +122,17 @@ digest_get_signature_oid(cms_context *cms)
 }
 
 int
-digest_get_digest_size(cms_context *cms)
+digest_get_authenticode_size(cms_context *cms)
 {
 	unsigned int i = cms->selected_digest;
-	return digest_params[i].size;
+	return digest_params[i].authenticode_digest_size;
+}
+
+int
+digest_get_cms_size(cms_context *cms)
+{
+	unsigned int i = cms->selected_digest;
+	return digest_params[i].cms_digest_size;
 }
 
 static CK_MECHANISM_TYPE
@@ -1321,7 +1345,7 @@ generate_digest_begin(cms_context *cms)
 
 	for (unsigned int i = 0; i < n_digest_params; i++) {
 		digests[i].pk11ctx = PK11_CreateDigestContext(
-						digest_params[i].digest_tag);
+				digest_params[i].authenticode_digest_tag);
 		if (!digests[i].pk11ctx)
 			cngotoerr(err, cms, "could not create digest context");
 
@@ -1359,13 +1383,15 @@ generate_digest_finish(cms_context *cms)
 			cngotoerr(err, cms, "could not allocate memory");
 
 		digest->type = siBuffer;
-		digest->len = digest_params[i].size;
-		digest->data = PORT_ArenaZAlloc(cms->arena, digest_params[i].size);
+		digest->len = digest_params[i].authenticode_digest_size;
+		digest->data = PORT_ArenaZAlloc(cms->arena,
+				digest_params[i].authenticode_digest_size);
 		if (digest->data == NULL)
 			cngotoerr(err, cms, "could not allocate memory");
 
 		PK11_DigestFinal(cms->digests[i].pk11ctx,
-			digest->data, &digest->len, digest_params[i].size);
+			digest->data, &digest->len,
+			digest_params[i].authenticode_digest_size);
 		PK11_Finalize(cms->digests[i].pk11ctx);
 		PK11_DestroyContext(cms->digests[i].pk11ctx, PR_TRUE);
 		cms->digests[i].pk11ctx = NULL;

--- a/src/cms_common.c
+++ b/src/cms_common.c
@@ -56,6 +56,22 @@ const struct digest_param digest_params[] = {
 		.size = 20
 	},
 #endif
+	[DIGEST_PARAM_ML_DSA_44] = {
+		.name = "ml-dsa-44",
+		.digest_tag = SEC_OID_SHA256,
+		.signature_tag = SEC_OID_ML_DSA_44,
+		.digest_encryption_tag = SEC_OID_ML_DSA_44,
+		.efi_guid = &efi_guid_sha256,
+		.size = 32
+	},
+	[DIGEST_PARAM_ML_DSA_65] = {
+		.name = "ml-dsa-65",
+		.digest_tag = SEC_OID_SHA256,
+		.signature_tag = SEC_OID_ML_DSA_65,
+		.digest_encryption_tag = SEC_OID_ML_DSA_65,
+		.efi_guid = &efi_guid_sha256,
+		.size = 32
+	},
 	[DIGEST_PARAM_ML_DSA_87] = {
 		.name = "ml-dsa-87",
 		.digest_tag = SEC_OID_SHA256,
@@ -98,7 +114,9 @@ digest_get_digest_size(cms_context *cms)
 static CK_MECHANISM_TYPE
 get_token_mechanism(cms_context *cms)
 {
-	if (cms->selected_digest == DIGEST_PARAM_ML_DSA_87)
+	if ((cms->selected_digest == DIGEST_PARAM_ML_DSA_44) ||
+	    (cms->selected_digest == DIGEST_PARAM_ML_DSA_65) ||
+	    (cms->selected_digest == DIGEST_PARAM_ML_DSA_87))
 		return CKM_ML_DSA;
 	return CKM_RSA_PKCS;
 }
@@ -1811,8 +1829,25 @@ cms_context_detect_algorithm(cms_context *cms)
 		return -1;
 
 	KeyType kt = CERT_GetCertKeyType(&cms->cert->subjectPublicKeyInfo);
-	if (kt == mldsaKey)
-		cms->selected_digest = DIGEST_PARAM_ML_DSA_87;
+	if (kt == mldsaKey) {
+		SECOidTag tag =
+			SECOID_GetAlgorithmTag(&cms->cert->subjectPublicKeyInfo.algorithm);
+
+		switch (tag) {
+			case SEC_OID_ML_DSA_44:
+				cms->selected_digest = DIGEST_PARAM_ML_DSA_44;
+				break;
+
+			case SEC_OID_ML_DSA_65:
+				cms->selected_digest = DIGEST_PARAM_ML_DSA_65;
+				break;
+
+			case SEC_OID_ML_DSA_87:
+			default:
+				cms->selected_digest = DIGEST_PARAM_ML_DSA_87;
+				break;
+		}
+	}
 
 	return 0;
 }

--- a/src/cms_common.h
+++ b/src/cms_common.h
@@ -75,11 +75,13 @@ struct digest {
 
 struct digest_param {
 	char *name;
-	SECOidTag digest_tag;
+	SECOidTag authenticode_digest_tag;
+	SECOidTag cms_digest_tag;
 	SECOidTag signature_tag;
 	SECOidTag digest_encryption_tag;
 	const efi_guid_t *efi_guid;
-	int size;
+	int authenticode_digest_size;
+	int cms_digest_size;
 };
 
 extern const struct digest_param digest_params[];
@@ -246,10 +248,12 @@ extern int find_certificate_by_issuer_and_sn(cms_context *cms,
 extern int find_slot_for_token(cms_context *cms, PK11SlotInfo **slot);
 extern int cms_context_detect_algorithm(cms_context *cms);
 
-extern SECOidTag digest_get_digest_oid(cms_context *cms);
+extern SECOidTag digest_get_authenticode_oid(cms_context *cms);
+extern SECOidTag digest_get_cms_oid(cms_context *cms);
 extern SECOidTag digest_get_encryption_oid(cms_context *cms);
 extern SECOidTag digest_get_signature_oid(cms_context *cms);
-extern int digest_get_digest_size(cms_context *cms);
+extern int digest_get_authenticode_size(cms_context *cms);
+extern int digest_get_cms_size(cms_context *cms);
 extern void cms_set_pw_callback(cms_context *cms, PK11PasswordFunc func);
 extern void cms_set_pw_data(cms_context *cms, secuPWData *pwdata);
 

--- a/src/cms_common.h
+++ b/src/cms_common.h
@@ -68,7 +68,9 @@ struct digest {
 
 #define DIGEST_PARAM_SHA256	0
 #define DIGEST_PARAM_SHA1	1
-#define DIGEST_PARAM_ML_DSA_87	2
+#define DIGEST_PARAM_ML_DSA_44	2
+#define DIGEST_PARAM_ML_DSA_65	3
+#define DIGEST_PARAM_ML_DSA_87	4
 #define DEFAULT_DIGEST_PARAM	DIGEST_PARAM_SHA256
 
 struct digest_param {

--- a/src/content_info.c
+++ b/src/content_info.c
@@ -179,7 +179,7 @@ generate_spc_digest_info(cms_context *cms, SECItem *dip)
 	memset(&di, '\0', sizeof (di));
 
 	if (generate_algorithm_id(cms, &di.digestAlgorithm,
-			digest_get_digest_oid(cms)) < 0)
+			digest_get_authenticode_oid(cms)) < 0)
 		return -1;
 	unsigned int i = cms->selected_digest;
 	memcpy(&di.digest, cms->digests[i].pe_digest, sizeof (di.digest));
@@ -298,12 +298,12 @@ generate_cinfo_digest(cms_context *cms, SpcContentInfo *cip)
 	};
 	
 	PK11Context *ctx = NULL;
-	SECOidData *oid = SECOID_FindOIDByTag(digest_get_digest_oid(cms));
+	SECOidData *oid = SECOID_FindOIDByTag(digest_get_cms_oid(cms));
 	if (oid == NULL)
 		return -1;
 
 	cms->ci_digest = SECITEM_AllocItem(cms->arena, NULL,
-					digest_get_digest_size(cms));
+					digest_get_cms_size(cms));
 	if (!cms->ci_digest)
 		goto err;
 
@@ -317,7 +317,7 @@ generate_cinfo_digest(cms_context *cms, SpcContentInfo *cip)
 		goto err;
 	if (PK11_DigestFinal(ctx, cms->ci_digest->data,
 				&cms->ci_digest->len,
-				digest_get_digest_size(cms)) != SECSuccess)
+				digest_get_cms_size(cms)) != SECSuccess)
 		goto err;
 
 	if (content_is_empty(cms->ci_digest->data, cms->ci_digest->len)) {
@@ -325,7 +325,7 @@ generate_cinfo_digest(cms_context *cms, SpcContentInfo *cip)
 		goto err;
 	}
 
-	if ((long long)cms->ci_digest->len > digest_get_digest_size(cms))
+	if ((long long)cms->ci_digest->len > digest_get_cms_size(cms))
 		goto err;
 
 	PK11_DestroyContext(ctx, PR_TRUE);

--- a/src/efikeygen.c
+++ b/src/efikeygen.c
@@ -744,6 +744,20 @@ struct algorithm algorithms[] = {
 	 .key_bits = 4096,
 	 .exponent = 0x010001ul,
 	},
+	{.name = "ml-dsa-44",
+	 .keygen_mech = CKM_ML_DSA_KEY_PAIR_GEN,
+	 .sig_oid = SEC_OID_ML_DSA_44,
+	 .key_type = CKK_ML_DSA,
+	 .key_bits = 0,
+	 .exponent = 0,
+	},
+	{.name = "ml-dsa-65",
+	 .keygen_mech = CKM_ML_DSA_KEY_PAIR_GEN,
+	 .sig_oid = SEC_OID_ML_DSA_65,
+	 .key_type = CKK_ML_DSA,
+	 .key_bits = 0,
+	 .exponent = 0,
+	},
 	{.name = "ml-dsa-87",
 	 .keygen_mech = CKM_ML_DSA_KEY_PAIR_GEN,
 	 .sig_oid = SEC_OID_ML_DSA_87,
@@ -774,6 +788,12 @@ struct digest_algorithm digest_algorithms[] = {
 	},
 	{.name = "sha512",
 	 .sec_oid = SEC_OID_PKCS1_SHA512_WITH_RSA_ENCRYPTION,
+	},
+	{.name = "ml-dsa-44",
+	 .sec_oid = SEC_OID_ML_DSA_44,
+	},
+	{.name = "ml-dsa-65",
+	 .sec_oid = SEC_OID_ML_DSA_65,
 	},
 	{.name = "ml-dsa-87",
 	 .sec_oid = SEC_OID_ML_DSA_87,
@@ -1120,9 +1140,17 @@ int main(int argc, char *argv[])
 
 	switch (selected_algo->keygen_mech) {
 	case CKM_ML_DSA_KEY_PAIR_GEN:
-		cms->selected_digest = DIGEST_PARAM_ML_DSA_87;
 
 		switch (digest_tag) {
+		case SEC_OID_ML_DSA_44:
+			cms->selected_digest = DIGEST_PARAM_ML_DSA_44;
+			break;
+		case SEC_OID_ML_DSA_65:
+			cms->selected_digest = DIGEST_PARAM_ML_DSA_65;
+			break;
+		case SEC_OID_ML_DSA_87:
+			cms->selected_digest = DIGEST_PARAM_ML_DSA_87;
+			break;
 		case SEC_OID_PKCS1_SHA256_WITH_RSA_ENCRYPTION:
 		case SEC_OID_PKCS1_SHA384_WITH_RSA_ENCRYPTION:
 		case SEC_OID_PKCS1_SHA512_WITH_RSA_ENCRYPTION:
@@ -1147,6 +1175,8 @@ int main(int argc, char *argv[])
 		case SEC_OID_PKCS1_SHA512_WITH_RSA_ENCRYPTION:
 			selected_algo->sig_oid = SEC_OID_PKCS1_SHA512_WITH_RSA_ENCRYPTION;
 			break;
+		case SEC_OID_ML_DSA_44:
+		case SEC_OID_ML_DSA_65:
 		case SEC_OID_ML_DSA_87:
 			errx(1, "RSA algorithm cannot used with ML-DSA digest");
 			break;
@@ -1213,7 +1243,18 @@ int main(int argc, char *argv[])
 		PK11RSAGenParams rsaparams;
 		CK_ML_DSA_PARAMETER_SET_TYPE mldsa_params;
 		if (selected_algo->keygen_mech == CKM_ML_DSA_KEY_PAIR_GEN) {
-			mldsa_params = CKP_ML_DSA_87;
+			switch (selected_algo->sig_oid) {
+				case SEC_OID_ML_DSA_44:
+					mldsa_params = CKP_ML_DSA_44;
+					break;
+				case SEC_OID_ML_DSA_65:
+					mldsa_params = CKP_ML_DSA_65;
+					break;
+				case SEC_OID_ML_DSA_87:
+				default:
+					mldsa_params = CKP_ML_DSA_87;
+					break;
+			}
 			keygen_params = &mldsa_params;
 		} else {
 			rsaparams.keySizeInBits = selected_algo->key_bits;

--- a/src/file_kmod.c
+++ b/src/file_kmod.c
@@ -72,7 +72,7 @@ kmod_write_signature(cms_context *cms, int outfd)
 
 	cinfo = SEC_PKCS7CreateSignedData(cms->cert,
 					  certUsageObjectSigner, NULL,
-					  digest_get_digest_oid(cms),
+					  digest_get_authenticode_oid(cms),
 					  digest, NULL, NULL);
 	if (!cinfo) {
 		cms->log(cms, LOG_ERR, "failed to create signed data: %s (%s)",

--- a/src/signed_data.c
+++ b/src/signed_data.c
@@ -14,7 +14,8 @@
 #include <nss.h>
 
 static int
-generate_algorithm_id_list(cms_context *cms, SECAlgorithmID ***algorithm_list_p)
+generate_algorithm_id_list(cms_context *cms, SECAlgorithmID ***algorithm_list_p,
+			   SECOidTag digest_oid)
 {
 	SECAlgorithmID **algorithms = NULL;
 	int err = 0;
@@ -30,8 +31,7 @@ generate_algorithm_id_list(cms_context *cms, SECAlgorithmID ***algorithm_list_p)
 		goto err_list;
 	}
 
-	if (generate_algorithm_id(cms, algorithms[0],
-			digest_get_digest_oid(cms)) < 0) {
+	if (generate_algorithm_id(cms, algorithms[0], digest_oid) < 0) {
 		err = PORT_GetError();
 		goto err_item;
 	}
@@ -276,7 +276,8 @@ generate_spc_signed_data(cms_context *cms, SECItem *sdp)
 		cmsreterr(-1, cms, "could not encode integer");
 	}
 
-	if (generate_algorithm_id_list(cms, &sd.algorithms) < 0) {
+	if (generate_algorithm_id_list(cms, &sd.algorithms,
+			digest_get_cms_oid(cms)) < 0) {
 		PORT_ArenaRelease(cms->arena, mark);
 		cms->ci_digest = NULL;
 		return -1;
@@ -353,7 +354,8 @@ generate_authvar_signed_data(cms_context *cms, SECItem *sdp)
 		cmsreterr(-1, cms, "could not encode integer");
 	}
 
-	if (generate_algorithm_id_list(cms, &sd.algorithms) < 0) {
+	if (generate_algorithm_id_list(cms, &sd.algorithms,
+			digest_get_authenticode_oid(cms)) < 0) {
 		PORT_ArenaRelease(cms->arena, mark);
 		return -1;
 	}

--- a/src/signer_info.c
+++ b/src/signer_info.c
@@ -355,7 +355,7 @@ generate_spc_signer_info(cms_context *cms, SpcSignerInfo *sip)
 	si.sid.signerValue.iasn.serial = cms->cert->serialNumber;
 
 	if (generate_algorithm_id(cms, &si.digestAlgorithm,
-			digest_get_digest_oid(cms)) < 0)
+			digest_get_cms_oid(cms)) < 0)
 		goto err;
 
 
@@ -409,7 +409,7 @@ generate_authvar_signer_info(cms_context *cms, SpcSignerInfo *sip)
 	si.sid.signerValue.iasn.serial = cms->cert->serialNumber;
 
 	if (generate_algorithm_id(cms, &si.digestAlgorithm,
-			digest_get_digest_oid(cms)) < 0)
+			digest_get_authenticode_oid(cms)) < 0)
 		goto err;
 
 	si.signedAttrs.len = 0;


### PR DESCRIPTION
This PR is about adding:
- Support for ML-DSA-65 and ML-DSA-44
- Follow RFC 9882 and use SHA-512 for CMS hashing